### PR TITLE
fix: use absolute $HOME paths in home::symlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ TODO: Add a short summary of this module.
 - `p6df::modules::awscdk::home::symlink()`
 - `p6df::modules::awscdk::init(_module, dir)`
   - Args:
-    - _module - 
-    - dir - 
+    - _module -
+    - dir -
 - `p6df::modules::awscdk::langs()`
 - `p6df::modules::awscdk::langs::awscdk()`
 - `p6df::modules::awscdk::prompt::mod()`
@@ -54,7 +54,7 @@ TODO: Add a short summary of this module.
 - `p6df::modules::awscdk::docker::build()`
 - `p6df::modules::awscdk::docker::run(...)`
   - Args:
-    - ... - 
+    - ... -
 
 ## Hierarchy
 

--- a/init.zsh
+++ b/init.zsh
@@ -39,9 +39,9 @@ p6df::modules::awscdk::external::brew() {
 ######################################################################
 p6df::modules::awscdk::home::symlink() {
 
-  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-awscdk/share/.nuget" ".nuget"
-  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-awscdk/share/.dotnet" ".dotnet"
-  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-awscdk/share/.templateengine" ".templateengine"
+  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-awscdk/share/.nuget" "$HOME/.nuget"
+  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-awscdk/share/.dotnet" "$HOME/.dotnet"
+  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-awscdk/share/.templateengine" "$HOME/.templateengine"
 
   p6_return_void
 }


### PR DESCRIPTION
Symlink targets were using relative paths (e.g. `.aws`) instead of absolute `$HOME/.aws`. Fixes symlinks when not run from $HOME.