### PR TITLE
fix: rename external::brew() -> external::brews() to match framework dispatch

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -16,11 +16,11 @@ p6df::modules::awscdk::deps() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::awscdk::external::brew()
+# Function: p6df::modules::awscdk::external::brews()
 #
 #>
 ######################################################################
-p6df::modules::awscdk::external::brew() {
+p6df::modules::awscdk::external::brews() {
 
   p6df::core::homebrew::cmd::brew tap isen-ng/dotnet-sdk-versions
   p6df::core::homebrew::cli::brew::install --cask dotnet-sdk3-1-400


### PR DESCRIPTION
## Summary
- Rename `external::brew()` → `external::brews()` to match the plural form dispatched by `p6df-core/lib/module.zsh`

## Test plan
- [ ] Verify `p6df::core::module::brews` dispatch resolves correctly