### PR TITLE
chore(awscdk): rename home::symlink to home::symlinks, add dotnet gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 share/.dotnet/
+share/.nuget/
+share/.templateengine/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-share/
+share/.dotnet/

--- a/init.zsh
+++ b/init.zsh
@@ -32,12 +32,12 @@ p6df::modules::awscdk::external::brews() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::awscdk::home::symlink()
+# Function: p6df::modules::awscdk::home::symlinks()
 #
 #  Environment:	 P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
 #>
 ######################################################################
-p6df::modules::awscdk::home::symlink() {
+p6df::modules::awscdk::home::symlinks() {
 
   p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-awscdk/share/.nuget" "$HOME/.nuget"
   p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-awscdk/share/.dotnet" "$HOME/.dotnet"


### PR DESCRIPTION
## What
Rename singular to plural. Add share/.dotnet/ to .gitignore as catch-all.

## Why
Framework dispatches plural only. .dotnet/ contains machine-specific runtime sentinel files that should not be tracked.

## Test plan
- `p6df home symlinks` works correctly
- `git check-ignore share/.dotnet/` confirms ignored

## Dependencies
None