### PR TITLE
fix(prompt): rename init/prompt::mod to env::init/prompt::system using p6_return_words

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -121,5 +121,5 @@ p6df::modules::awscdk::clones() {
 ######################################################################
 p6df::modules::awscdk::prompt::system() {
 
-  p6_return_words 'awscdk' '$CDK_DEPLOY_ACCOUNT' '$CDK_DEPLOY_REGION' '$CDK_DEFAULT_ACCOUNT' '$CDK_DEFAULT_REGION'
+  p6_return_words 'awscdk' "$" "$" "$" "$"
 }

--- a/init.zsh
+++ b/init.zsh
@@ -34,7 +34,7 @@ p6df::modules::awscdk::external::brews() {
 #
 # Function: p6df::modules::awscdk::home::symlinks()
 #
-#  Environment:	 P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
+#  Environment:	 HOME P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
 #>
 ######################################################################
 p6df::modules::awscdk::home::symlinks() {
@@ -49,21 +49,15 @@ p6df::modules::awscdk::home::symlinks() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::awscdk::init(_module, dir)
-#
-#  Args:
-#	_module -
-#	dir -
+# Function: p6df::modules::awscdk::env::init()
 #
 #  Environment:	 DOTNET_ROOT
 #>
 ######################################################################
-p6df::modules::awscdk::init() {
+p6df::modules::awscdk::env::init() {
+
   local _module="$1"
-  local dir="$2"
-
-  p6_bootstrap "$dir"
-
+  local _dir="$2"
   p6_env_export "DOTNET_ROOT" "/opt/homebrew/opt/dotnet/libexec"
 
   p6_return_void
@@ -117,11 +111,15 @@ p6df::modules::awscdk::clones() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::awscdk::prompt::mod()
+# Function: words awscdk = p6df::modules::awscdk::prompt::system()
 #
+#  Returns:
+#	words - awscdk
+#
+#  Environment:	 CDK_DEFAULT_ACCOUNT CDK_DEFAULT_REGION CDK_DEPLOY_ACCOUNT CDK_DEPLOY_REGION
 #>
 ######################################################################
-p6df::modules::awscdk::prompt::mod() {
+p6df::modules::awscdk::prompt::system() {
 
-  p6_awscdk_prompt_info
+  p6_return_words 'awscdk' '$CDK_DEPLOY_ACCOUNT' '$CDK_DEPLOY_REGION' '$CDK_DEFAULT_ACCOUNT' '$CDK_DEFAULT_REGION'
 }

--- a/init.zsh
+++ b/init.zsh
@@ -121,5 +121,5 @@ p6df::modules::awscdk::clones() {
 ######################################################################
 p6df::modules::awscdk::prompt::system() {
 
-  p6_return_words 'awscdk' "$" "$" "$" "$"
+  p6_return_words 'awscdk' "$CDK_DEPLOY_ACCOUNT" "$CDK_DEPLOY_REGION" "$CDK_DEFAULT_ACCOUNT" "$CDK_DEFAULT_REGION"
 }


### PR DESCRIPTION
## What
Refactor prompt module with all local changes including p6_return_words quoting fix.

## Why
Split p6_return_words word and variable into separate quoted args; also includes related prompt/profile refactors.

## Test plan
- Verified diff contains expected changes

## Dependencies
None