### PR TITLE
fix(awscdk): use single-quoted variables in profile::mod (deferred eval)

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -121,5 +121,5 @@ p6df::modules::awscdk::clones() {
 ######################################################################
 p6df::modules::awscdk::prompt::system() {
 
-  p6_return_words 'awscdk' "$CDK_DEPLOY_ACCOUNT" "$CDK_DEPLOY_REGION" "$CDK_DEFAULT_ACCOUNT" "$CDK_DEFAULT_REGION"
+  p6_return_words 'awscdk' '$CDK_DEPLOY_ACCOUNT' '$CDK_DEPLOY_REGION' '$CDK_DEFAULT_ACCOUNT' '$CDK_DEFAULT_REGION'
 }


### PR DESCRIPTION
**What:** Restore single-quoted variables in profile::mod p6_return_words calls

**Why:** Variables are intentionally single-quoted; eval happens later via p6_return_words machinery. The SC2016 fix incorrectly expanded them at call time.

**Test plan:** Build CI passes

**Dependencies:** None