### PR TITLE
chore(init): reorder hooks per hook_api.md lifecycle order

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -1,11 +1,5 @@
 # shellcheck shell=bash
 ######################################################################
-#<
-#
-# Function: p6df::modules::awscdk::deps()
-#
-#>
-######################################################################
 p6df::modules::awscdk::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6awscdk
@@ -13,46 +7,6 @@ p6df::modules::awscdk::deps() {
   )
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::awscdk::external::brews()
-#
-#>
-######################################################################
-p6df::modules::awscdk::external::brews() {
-
-  p6df::core::homebrew::cmd::brew tap isen-ng/dotnet-sdk-versions
-  p6df::core::homebrew::cli::brew::install --cask dotnet-sdk3-1-400
-  p6df::core::homebrew::cli::brew::install dotnet
-
-  p6_return_void
-}
-
-######################################################################
-#<
-#
-# Function: p6df::modules::awscdk::home::symlinks()
-#
-#  Environment:	 HOME P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
-#>
-######################################################################
-p6df::modules::awscdk::home::symlinks() {
-
-  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-awscdk/share/.nuget" "$HOME/.nuget"
-  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-awscdk/share/.dotnet" "$HOME/.dotnet"
-  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-awscdk/share/.templateengine" "$HOME/.templateengine"
-
-  p6_return_void
-}
-
-######################################################################
-#<
-#
-# Function: p6df::modules::awscdk::env::init()
-#
-#  Environment:	 DOTNET_ROOT
-#>
 ######################################################################
 p6df::modules::awscdk::env::init() {
 
@@ -64,11 +18,25 @@ p6df::modules::awscdk::env::init() {
 }
 
 ######################################################################
-#<
-#
-# Function: p6df::modules::awscdk::langs()
-#
-#>
+p6df::modules::awscdk::home::symlinks() {
+
+  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-awscdk/share/.nuget" "$HOME/.nuget"
+  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-awscdk/share/.dotnet" "$HOME/.dotnet"
+  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-awscdk/share/.templateengine" "$HOME/.templateengine"
+
+  p6_return_void
+}
+
+######################################################################
+p6df::modules::awscdk::external::brews() {
+
+  p6df::core::homebrew::cmd::brew tap isen-ng/dotnet-sdk-versions
+  p6df::core::homebrew::cli::brew::install --cask dotnet-sdk3-1-400
+  p6df::core::homebrew::cli::brew::install dotnet
+
+  p6_return_void
+}
+
 ######################################################################
 p6df::modules::awscdk::langs() {
 
@@ -78,6 +46,38 @@ p6df::modules::awscdk::langs() {
   p6_return_void
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::awscdk::deps()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::awscdk::external::brews()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::awscdk::home::symlinks()
+#
+#  Environment:	 HOME P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::awscdk::env::init()
+#
+#  Environment:	 DOTNET_ROOT
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::awscdk::langs()
+#
+#>
 ######################################################################
 #<
 #

--- a/init.zsh
+++ b/init.zsh
@@ -1,5 +1,11 @@
 # shellcheck shell=bash
 ######################################################################
+#<
+#
+# Function: p6df::modules::awscdk::deps()
+#
+#>
+######################################################################
 p6df::modules::awscdk::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6awscdk
@@ -7,6 +13,13 @@ p6df::modules::awscdk::deps() {
   )
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::awscdk::env::init()
+#
+#  Environment:	 DOTNET_ROOT
+#>
 ######################################################################
 p6df::modules::awscdk::env::init() {
 
@@ -18,6 +31,13 @@ p6df::modules::awscdk::env::init() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::awscdk::home::symlinks()
+#
+#  Environment:	 HOME P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
+#>
+######################################################################
 p6df::modules::awscdk::home::symlinks() {
 
   p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-awscdk/share/.nuget" "$HOME/.nuget"
@@ -27,6 +47,12 @@ p6df::modules::awscdk::home::symlinks() {
   p6_return_void
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::awscdk::external::brews()
+#
+#>
 ######################################################################
 p6df::modules::awscdk::external::brews() {
 
@@ -38,6 +64,12 @@ p6df::modules::awscdk::external::brews() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::awscdk::langs()
+#
+#>
+######################################################################
 p6df::modules::awscdk::langs() {
 
   p6_js_npm_global_install "aws-cdk"
@@ -46,38 +78,6 @@ p6df::modules::awscdk::langs() {
   p6_return_void
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::awscdk::deps()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::awscdk::external::brews()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::awscdk::home::symlinks()
-#
-#  Environment:	 HOME P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::awscdk::env::init()
-#
-#  Environment:	 DOTNET_ROOT
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::awscdk::langs()
-#
-#>
 ######################################################################
 #<
 #


### PR DESCRIPTION
## What
Reorder hook functions in `init.zsh` to match the canonical lifecycle order defined in `p6df-core/doc/hook_api.md`.

**Lifecycle:** `deps → init → env::init → path::init → cdpath::init → fpath::init → completions::init → aliases::init → langmgr::init → prompt::init`

**Install-time:** `home::symlinks → external::brews → langs → mcp → vscodes → vscodes::config`

**Profile:** `profile::on → profile::off → profile::mod → prompt::mod::bottom`

## Why
Hook functions were defined in inconsistent order across modules. Enforcing the canonical order makes the files easier to audit and ensures the documented execution sequence is visually obvious.

## Test plan
- [ ] Verified hook order with automated check (all pass)
- [ ] No functional changes — only block reordering

## Dependencies
None